### PR TITLE
add api_url and api_key to kegbot_master config

### DIFF
--- a/pykeg/kegbot_master.cfg.example
+++ b/pykeg/kegbot_master.cfg.example
@@ -40,7 +40,7 @@
 
 [kegbot_core]
 _enabled = True
-api_url = 'http://domain.com/api'
+api_url = 'http://example.com/api'
 api_key = 'API_KEY'
 
 [kegboard_daemon]


### PR DESCRIPTION
core requires api information now. does sound server require it as well?
