### PR TITLE
NewSerialSoft update for newer compilers.

### DIFF
--- a/controller/kegboard/NewSoftSerial.cpp
+++ b/controller/kegboard/NewSoftSerial.cpp
@@ -180,7 +180,7 @@ inline void NewSoftSerial::tunedDelay(uint16_t delay) {
     "cpi %A0, 0xFF \n\t"
     "cpc %B0, %1 \n\t"
     "brne .-10 \n\t"
-    : "+r" (delay), "+a" (tmp)
+    : "+w" (delay), "+a" (tmp)
     : "0" (delay)
     );
 }


### PR DESCRIPTION
Before update on newer compilers an error would occur:
"Error: register r24, r26, r28 or r30 required"

This is fixed now.  Should be backwards compatible(tested on a few machines).
