### PR TITLE
Adding support for magnetic stripe cards and pin change interrupts.

### DIFF
--- a/controller/kegboard/MagStripe.cpp
+++ b/controller/kegboard/MagStripe.cpp
@@ -1,0 +1,226 @@
+//
+//  MagStripe.m
+//  KegBoard
+//
+//  Handles input from Magnetic stripe card readers
+//  Based on code by Stephan King http://www.kingsdesign.com
+//
+//  Created by John Boiles on 9/25/10.
+//
+//  This program is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License
+//  as published by the Free Software Foundation; either version 2
+//  of the License, or (at your option) any later version.
+
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "MagStripe.h"
+#include "pins_arduino.h"
+#include "WProgram.h"
+
+MagStripe::MagStripe(uint8_t clockPin, uint8_t dataPin, uint8_t cardPresentPin) {
+  _clockPin = clockPin;
+  pinMode(clockPin, INPUT);
+  _dataPin = dataPin;
+  pinMode(dataPin, INPUT);
+  _cardPresentPin = cardPresentPin;
+  pinMode(cardPresentPin, INPUT);
+  reset();
+}
+
+int MagStripe::getData(uint8_t **data) {
+  // If card is present, we're reading data, don't return anything
+  if (digitalRead(_cardPresentPin) == LOW) return 0;
+  // If data is available, return data, reset values
+  if (dataAvailable) {
+    decode();
+    *data = _cardData;
+    int dataSize = _dataSize;
+    reset();
+    return dataSize;
+  }
+  return 0;
+}
+
+void MagStripe::reset() {
+  _bufferIndex = 0;
+  _dataSize = 0;
+  dataAvailable = false;
+}
+
+// Writes the bit to the buffer
+void MagStripe::clockData() {
+  if (_bufferIndex > MAGSTRIPE_BUFFER_SIZE) return;
+  _buffer[_bufferIndex] = !digitalRead(_dataPin);
+  _bufferIndex++;
+  dataAvailable = true;
+}
+
+// prints the buffer
+void MagStripe::printBuffer() {
+#if MAGSTRIPE_DEBUG
+  Serial.print("Buffer:");
+  for (int j = 0; j < MAGSTRIPE_BUFFER_SIZE; j = j + 1) {
+    Serial.println(_buffer[j], DEC);
+  }
+  Serial.println("End Buffer");
+#endif
+}
+
+// Find the index of the start sentinel ';'
+int MagStripe::findStartSentinal() {
+  uint8_t queue[5];
+  int sentinal = 0;
+
+  for (int j = 0; j < MAGSTRIPE_BUFFER_SIZE; j = j + 1) {
+    queue[4] = queue[3];
+    queue[3] = queue[2];
+    queue[2] = queue[1];
+    queue[1] = queue[0];
+    queue[0] = _buffer[j];
+
+#if MAGSTRIPE_DEBUG
+    Serial.print(queue[0], DEC);
+    Serial.print(queue[1], DEC);
+    Serial.print(queue[2], DEC);
+    Serial.print(queue[3], DEC);
+    Serial.println(queue[4], DEC);
+#endif
+
+    if (queue[0] == 0 & queue[1] == 1 & queue[2] == 0 & queue[3] == 1 & queue[4] == 1) {
+      sentinal = j - 4;
+      break;
+    }
+  }
+
+#if MAGSTRIPE_DEBUG
+  Serial.print("sentinal:");
+  Serial.println(sentinal);
+  Serial.println("");
+#endif
+
+  return sentinal;
+}
+
+void MagStripe::decode() {
+  int sentinal = findStartSentinal();
+  int i = 0;
+  int k = 0;
+  uint8_t thisByte[5];
+
+  for (int j = sentinal; j < MAGSTRIPE_BUFFER_SIZE - sentinal; j = j + 1) {
+    thisByte[i] = _buffer[j];
+    i++;
+    if (i % 5 == 0) {
+      i = 0;
+      if (thisByte[0] == 0 & thisByte[1] == 0 & thisByte[2] == 0 & thisByte[3] == 0 & thisByte[4] == 0) {
+        break;
+      }
+      uint8_t value = saveByte(thisByte);
+      // TODO(johnb): Do some validation. Maybe return false if there wasn't an end sentinel.
+      if (value == '?') break; // End sentinel
+    }
+  }
+#if MAGSTRIPE_DEBUG 
+  Serial.print("Stripe_Data:");
+  for (k = 0; k < _dataSize; k = k + 1) {
+    Serial.print(_cardData[k]);
+  }
+  Serial.println("");
+#endif
+}
+
+uint8_t MagStripe::saveByte(uint8_t thisByte[]) {
+#if MAGSTRIPE_DEBUG
+  for (int i = 0; i < 5; i = i + 1) {
+    Serial.print(thisByte[i], DEC);
+  }
+  Serial.print("\t");
+  Serial.print(decodeByte(thisByte));
+  Serial.println("");
+#endif
+  uint8_t value = decodeByte(thisByte);
+  if (value == ';') return ';'; // Ignore start sentinel
+  if (value == '?') return '?'; // Ignore end sentinel
+  _cardData[_dataSize] = value;
+  _dataSize++;
+  return value;
+}
+
+uint8_t MagStripe::decodeByte(uint8_t thisByte[]) {
+  // 4 bits then parity
+  if (thisByte[0] == 0 & thisByte[1] == 0 & thisByte[2] == 0 & thisByte[3] == 0 & thisByte[4] == 1){
+    return '0';
+  }
+
+  if (thisByte[0] == 1 & thisByte[1] == 0 & thisByte[2] == 0 & thisByte[3] == 0 & thisByte[4] == 0){
+    return '1';
+  }
+
+  if (thisByte[0] == 0 & thisByte[1] == 1 & thisByte[2] == 0 & thisByte[3] == 0 & thisByte[4] == 0){
+    return '2';
+  }
+
+  if (thisByte[0] == 1 & thisByte[1] == 1 & thisByte[2] == 0 & thisByte[3] == 0 & thisByte[4] == 1){
+    return '3';
+  }
+
+  if (thisByte[0] == 0 & thisByte[1] == 0 & thisByte[2] == 1 & thisByte[3] == 0 & thisByte[4] == 0){
+    return '4';
+  }
+
+  if (thisByte[0] == 1 & thisByte[1] == 0 & thisByte[2] == 1 & thisByte[3] == 0 & thisByte[4] == 1){
+    return '5';
+  }
+
+  if (thisByte[0] == 0 & thisByte[1] == 1 & thisByte[2] == 1 & thisByte[3] == 0 & thisByte[4] == 1){
+    return '6';
+  }
+
+  if (thisByte[0] == 1 & thisByte[1] == 1 & thisByte[2] == 1 & thisByte[3] == 0 & thisByte[4] == 0){
+    return '7';
+  }
+
+  if (thisByte[0] == 0 & thisByte[1] == 0 & thisByte[2] == 0 & thisByte[3] == 1 & thisByte[4] == 0){
+    return '8';
+  }
+
+  if (thisByte[0] == 1 & thisByte[1] == 0 & thisByte[2] == 0 & thisByte[3] == 1 & thisByte[4] == 1){
+    return '9';
+  }
+
+  if (thisByte[0] == 0 & thisByte[1] == 1 & thisByte[2] == 0 & thisByte[3] == 1 & thisByte[4] == 1){
+    return ':';
+  }
+
+  if (thisByte[0] == 1 & thisByte[1] == 1 & thisByte[2] == 0 & thisByte[3] == 1 & thisByte[4] == 0){
+    return ';';
+  }
+
+  if (thisByte[0] == 0 & thisByte[1] == 0 & thisByte[2] == 1 & thisByte[3] == 1 & thisByte[4] == 1){
+    return '<';
+  }
+
+  if (thisByte[0] == 1 & thisByte[1] == 0 & thisByte[2] == 1 & thisByte[3] == 1 & thisByte[4] == 0){
+    return '=';
+  }
+
+  if (thisByte[0] == 0 & thisByte[1] == 1 & thisByte[2] == 1 & thisByte[3] == 1 & thisByte[4] == 0){
+    return '>';
+  }
+
+  if (thisByte[0] == 1 & thisByte[1] == 1 & thisByte[2] == 1 & thisByte[3] == 1 & thisByte[4] == 1){
+    return '?';
+  }
+
+  return '*';
+}
+
+

--- a/controller/kegboard/MagStripe.h
+++ b/controller/kegboard/MagStripe.h
@@ -1,0 +1,49 @@
+//
+//  MagStripe.h
+//  KegBoard
+//
+//  Created by John Boiles on 9/25/10.
+//
+//  This program is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License
+//  as published by the Free Software Foundation; either version 2
+//  of the License, or (at your option) any later version.
+
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include <inttypes.h>
+
+#define MAGSTRIPE_DEBUG 0
+#define MAGSTRIPE_BUFFER_SIZE 250
+
+class MagStripe {
+  public:
+    MagStripe(uint8_t clockPin, uint8_t dataPin, uint8_t cardPresentPin);
+    bool dataAvailable;
+    void reset();
+    int getData(uint8_t **data);
+    void clockData();
+  private:
+    // TODO(johnb): Make this some sort of bit vector so we more efficiently use ram.
+    volatile uint8_t _buffer[MAGSTRIPE_BUFFER_SIZE];
+    volatile int _bufferIndex;
+    // Buffer for data, though this sucks since each uint8_t only uses a bit
+    uint8_t _cardData[40]; // holds card id string
+    int _dataSize; // length of card id string
+    uint8_t _clockPin;
+    uint8_t _dataPin;
+    uint8_t _cardPresentPin;
+    int findStartSentinal();
+    void decode();
+    uint8_t saveByte(uint8_t thisByte[]);
+    uint8_t decodeByte(uint8_t thisByte[]);
+    void printBuffer();
+};
+

--- a/controller/kegboard/NewSoftSerial.h
+++ b/controller/kegboard/NewSoftSerial.h
@@ -6,6 +6,7 @@ Copyright (c) 2006 David A. Mellis.  All rights reserved.
    multi-instance support, porting to 8MHz processors,
    various optimizations, PROGMEM delay tables, inverse logic and 
    direct port writing by Mikal Hart
+-- Support for using the separate PCInterrupt code by John Boiles
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public

--- a/controller/kegboard/PCInterrupt.cpp
+++ b/controller/kegboard/PCInterrupt.cpp
@@ -1,0 +1,150 @@
+//
+//  PCInterrupt.cpp
+//  KegBoard
+//
+//  An extension to the interrupt support for Arduino.
+//  Adds pin change interrupts to the external interrupts, allowing
+//  any pin to support external interrupts efficiently.
+//
+//  Theory: all IO pins on Atmega168 are covered by Pin Change Interrupts.
+//  The PCINT corresponding to the pin must be enabled and masked, and
+//  an ISR routine provided.  Since PCINTs are per port, not per pin, the ISR
+//  must use some logic to actually implement a per-pin interrupt service.
+//
+//  Pin to interrupt map:
+//  D0-D7 = PCINT 16-23 = PCIR2 = PD = PCIE2 = pcmsk2
+//  D8-D13 = PCINT 0-5 = PCIR0 = PB = PCIE0 = pcmsk0
+//  A0-A5 (D14-D19) = PCINT 8-13 = PCIR1 = PC = PCIE1 = pcmsk1
+//
+//  Originally by ckiick at http://www.arduino.cc/playground/Main/PcInt
+//  Modified to support RISING/FALLING by John Boiles 9/30/10
+//
+//  This program is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License
+//  as published by the Free Software Foundation; either version 2
+//  of the License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "pins_arduino.h"
+#include "WProgram.h"
+
+volatile uint8_t *PCintPortToInputMask[] = {
+  &PCMSK0,
+  &PCMSK1,
+  &PCMSK2
+};
+
+static int PCintMode[24];
+
+typedef void (*voidFuncPtr)(void);
+
+volatile static voidFuncPtr PCintFunc[24] = { NULL };
+
+volatile static uint8_t PCintLast[3];
+
+ void PCattachInterrupt(uint8_t pin, void (*userFunc)(void), int mode) {
+  uint8_t bit = digitalPinToBitMask(pin);
+  uint8_t port = digitalPinToPort(pin);
+  uint8_t slot;
+  volatile uint8_t *pcmask;
+
+  pinMode(pin, INPUT);
+  // map pin to PCIR register
+  if (port == NOT_A_PORT) {
+    return;
+  } 
+  else {
+    port -= 2;
+    pcmask = PCintPortToInputMask[port];
+  }
+
+  // Fix by Baziki. In the original sources there was a little bug,
+  // which caused analog ports to work incorrectly.
+  if (port == 1) {
+    slot = port * 8 + (pin - 14);
+  }
+  else {
+    slot = port * 8 + (pin % 8);
+  }
+
+  PCintMode[slot] = mode;
+  PCintFunc[slot] = userFunc;
+  // set the mask
+  *pcmask |= bit;
+  // enable the interrupt
+  PCICR |= 0x01 << port;
+}
+
+void PCdetachInterrupt(uint8_t pin) {
+  uint8_t bit = digitalPinToBitMask(pin);
+  uint8_t port = digitalPinToPort(pin);
+  volatile uint8_t *pcmask;
+
+  // map pin to PCIR register
+  if (port == NOT_A_PORT) {
+    return;
+  } else {
+    port -= 2;
+    pcmask = PCintPortToInputMask[port];
+  }
+
+  // disable the mask.
+  *pcmask &= ~bit;
+  // if that's the last one, disable the interrupt.
+  if (*pcmask == 0) {
+    PCICR &= ~(0x01 << port);
+  }
+}
+
+// common code for isr handler. "port" is the PCINT number.
+// there isn't really a good way to back-map ports and masks to pins.
+static void PCint(uint8_t port) {
+  uint8_t bit;
+  uint8_t curr;
+  uint8_t mask;
+  uint8_t pin;
+
+  // get the pin states for the indicated port.
+  curr = *portInputRegister(port+2);
+  mask = curr ^ PCintLast[port];
+  // mask is pins that have changed. screen out non pcint pins.
+  if ((mask &= *PCintPortToInputMask[port]) == 0) {
+    return;
+  }
+  // mask is pcint pins that have changed.
+  for (uint8_t i=0; i < 8; i++) {
+    bit = 0x01 << i;
+    if (bit & mask) {
+      pin = port * 8 + i;
+      // Trigger interrupt if mode is CHANGE, or if mode is RISING and
+      // the bit is currently high, or if mode is FALLING and bit is low.
+      if ((PCintMode[pin] == CHANGE
+          || ((PCintMode[pin] == RISING) && (curr & bit))
+          || ((PCintMode[pin] == FALLING) && !(curr & bit)))
+          && (PCintFunc[pin] != NULL)) {
+        PCintFunc[pin]();
+      }
+    }
+  }
+  // Save current pin values
+  PCintLast[port] = curr;
+}
+
+
+SIGNAL(PCINT0_vect) {
+  PCint(0);
+}
+SIGNAL(PCINT1_vect) {
+  PCint(1);
+}
+SIGNAL(PCINT2_vect) {
+  PCint(2);
+}

--- a/controller/kegboard/PCInterrupt.h
+++ b/controller/kegboard/PCInterrupt.h
@@ -1,0 +1,46 @@
+//
+//  PCInterrupt.h
+//  KegBoard
+//
+//  An extension to the interrupt support for Arduino.
+//  Adds pin change interrupts to the external interrupts, allowing
+//  any pin to support external interrupts efficiently.
+//
+//  Theory: all IO pins on Atmega168 are covered by Pin Change Interrupts.
+//  The PCINT corresponding to the pin must be enabled and masked, and
+//  an ISR routine provided.  Since PCINTs are per port, not per pin, the ISR
+//  must use some logic to actually implement a per-pin interrupt service.
+//
+//  Pin to interrupt map:
+//  D0-D7 = PCINT 16-23 = PCIR2 = PD = PCIE2 = pcmsk2
+//  D8-D13 = PCINT 0-5 = PCIR0 = PB = PCIE0 = pcmsk0
+//  A0-A5 (D14-D19) = PCINT 8-13 = PCIR1 = PC = PCIE1 = pcmsk1
+//
+//  Originally by ckiick at http://www.arduino.cc/playground/Main/PcInt
+//  Modified to support RISING/FALLING by John Boiles 9/30/10
+//
+//  This program is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License
+//  as published by the Free Software Foundation; either version 2
+//  of the License, or (at your option) any later version.
+
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include <inttypes.h>
+
+/*
+ * Dttach an interrupt to a specific pin using pin change interrupts.
+ */
+void PCattachInterrupt(uint8_t pin, void (*userFunc)(void), int mode);
+
+/*
+ * Detach an pin change interrupt from a specific pin.
+ */
+void PCdetachInterrupt(uint8_t pin);

--- a/controller/kegboard/kegboard_config.h
+++ b/controller/kegboard/kegboard_config.h
@@ -20,6 +20,9 @@
 // Enable ID-12 RFID?
 #define KB_ENABLE_ID12_RFID 1
 
+// Enable MagStripe reader?
+#define KB_ENABLE_MAGSTRIPE 0
+
 //
 // Pin configuration - KEGBOARD VERSION
 //
@@ -67,6 +70,11 @@
 #define KB_PIN_RELAY_D            A3
 #define KB_PIN_GPIO_A             A4
 #define KB_PIN_GPIO_B             A5
+
+
+#define KB_PIN_MAGSTRIPE_CLOCK    3
+#define KB_PIN_MAGSTRIPE_DATA     A4
+#define KB_PIN_MAGSTRIPE_CARD_PRESENT A5
 
 // Atmega1280 (aka Arduino mega) section
 #ifdef __AVR_ATmega1280__


### PR DESCRIPTION
Adding support for magnetic stripe cards and any devices that use the same clock+data standard (some HID Prox Point readers use this standard).

Also outfitting NewSoftSerial to use pin change interrupts. This allows any pin to be used as a software serial port (therefore the ID12 can be hooked up to any pins, theoretically). Note that I've only tested this at 9600 baud, and delays may need to be tweaked for other speeds. Since we're only using this for ID12 right now and the ID12 is 9600 bauds, this shouldn't be a big deal.

I put code that uses KB_PIN_METER_B inside #if because I use that pin for the magstripe reader (since it's available on the coaster).
