### PR TITLE
point site_media to static

### DIFF
--- a/pykeg/src/pykeg/web/urls.py
+++ b/pykeg/src/pykeg/web/urls.py
@@ -29,7 +29,7 @@ urlpatterns = patterns('',
     ### static media
     url(r'^site_media/(.*)$',
       'django.views.static.serve',
-      {'document_root': os.path.join(basedir(), 'media')},
+      {'document_root': os.path.join(basedir(), 'static')},
       name='site-media'),
 
     url(r'^media/(.*)$',


### PR DESCRIPTION
Fix issue #15 in which site_media pointed to old media directory.  This should point to the new static directory instead.  As a result the unkown_drinker images can now be found without sym-linking.
