### PR TITLE
Appengine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,15 @@ pykeg/src/pykeg/web/media/mugshots
 pykeg/src/pykeg/web/media/sounds
 pykeg/static
 
+# AppEngine development files
+pykeg/src/pykeg/common_settings.py
+pykeg/src/app.yaml
+
 ### controller
 controller/kegboard/build-cli
 controller/kegboard/board/*.b\#*
 controller/kegboard/board/*.s\#*
+
+### Eclipse files
+.project
+.pydevproject

--- a/pykeg/app.yaml.example
+++ b/pykeg/app.yaml.example
@@ -1,0 +1,20 @@
+application: kegbot-emaple-appengine
+version: 1-1-alpha
+runtime: python27
+api_version: 1
+threadsafe: true
+
+libraries:
+- name: django
+  version: "1.3"
+
+builtins:
+- django_wsgi: on
+
+handlers:
+- url: /favicon\.ico
+  static_files: pykeg/web/static/images/favicon.ico
+  upload: pykeg/web/static/images/favicon\.ico
+  
+- url: /.*
+  script: pykeg.web.wsgi_app.app

--- a/pykeg/pavement.py
+++ b/pykeg/pavement.py
@@ -1,0 +1,84 @@
+import os
+import sys
+from tempfile import mkdtemp
+
+from paver.easy import *
+import paver.doctools
+from paver.virtual import bootstrap
+
+# Import the setup.py module for configuration
+sys.path.insert(0, os.path.dirname(__file__))
+try:
+  kegbot = __import__("setup")
+finally:
+  sys.path.pop()
+
+CAN_SKIP = False
+VENV_DIR = "virtualenv"
+
+options(
+  bootstrap = Bunch(bootstrap_dir = VENV_DIR),
+  virtualenv = Bunch(
+      packages_to_install = kegbot.DEPENDENCIES,
+      no_site_packages = True,
+      script_name = os.path.join(VENV_DIR, 'bootstrap.py'),
+      dest_dir = VENV_DIR,
+      #paver_command_line = '_init',
+  )
+  #setup = kegbot.SETUP
+)
+
+@task
+def _bootstrap(options):
+  """Create virtualenv in ./virtualenv"""
+  print("Calling bootstrap")
+  bs = path(options.bootstrap_dir)
+  if not bs.exists:
+    bs.mkdir()
+
+  call_task('paver.virtual.bootstrap')
+  sh('%s %s' % (sys.executable, options.virtualenv.script_name))
+
+@task
+def clean_all():
+  bs = path(options.bootstrap_dir)
+  if bs.exists:
+    bs.rmtree()
+
+@task
+def gaedist():
+  """Build a Google AppEngine source distribution based on setup.py.
+
+  The setup involves several steps:
+    * create a distribution directory with the kegbot source code
+    * generate the dependency sources from setup.py
+    * copy the required libraries into the dist directory
+  """
+  venv = path(VENV_DIR)
+  if venv.exists and CAN_SKIP:
+    print("Skipping bootstrap. Virtualenv already installed")
+  else:
+    call_task('_bootstrap')
+
+  srcdir = path('src')
+  outdir = path('appengine')
+
+  # Cleanup the old distribution and copy the source again
+  outdir.rmtree()
+  #srcdir.copytree(outdir)
+  (outdir / 'kegbot.egg-info').rmtree() # remove the egg-info directory
+  (venv / "lib" / "python2.7" / "site-packages" / "PIL-1.1.7-py2.7-macosx-10.7-intel.egg").rmtree()
+
+  libs = venv / "lib/python2.7/site-packages"
+  for p in libs.dirs():
+    for dep in p.glob("*"):
+      name = dep.basename()
+      if name in ['man', 'EGG-INFO', 'pykeg']:
+        continue
+      #print(dep)
+      dep.copytree(outdir / name)
+
+
+  for d in outdir.dirs():
+    (srcdir / d.basename()).rmtree()
+    d.move(srcdir)

--- a/pykeg/setup.py
+++ b/pykeg/setup.py
@@ -1,104 +1,122 @@
 #!/usr/bin/env python
+"""Kegbot kegerator controller software
 
-from distribute_setup import use_setuptools
-use_setuptools()
-
-from setuptools import setup, find_packages
-
-VERSION = '0.9.0'
-SHORT_DESCRIPTION = 'Kegbot kegerator controller software'
-LONG_DESCRIPTION = """This package contains Kegbot core controller and Django
+This package contains Kegbot core controller and Django
 frontend package.
 
 Kegbot is a hardware and software system to record and monitor access to a beer
 kegerator.  For more information and documentation, see http://kegbot.org/
 """
 
-setup(
-    name = 'kegbot',
-    version = VERSION,
-    description = SHORT_DESCRIPTION,
-    long_description = LONG_DESCRIPTION,
-    author = 'mike wakerly',
-    author_email = 'opensource@hoho.com',
-    url = 'http://kegbot.org/',
-    packages = find_packages('src'),
-    package_dir = {
-      '' : 'src',
-    },
-    scripts = [
-      'distribute_setup.py',
-      'src/pykeg/bin/kegboard_daemon.py',
-      'src/pykeg/bin/kegboard_monitor.py',
-      'src/pykeg/bin/kegboard-tester.py',
-      'src/pykeg/bin/kegbot-admin.py',
-      'src/pykeg/bin/kegbot_core.py',
-      'src/pykeg/bin/kegbot_master.py',
-      'src/pykeg/bin/lcd_daemon.py',
-      'src/pykeg/bin/rfid_daemon.py',
-      'src/pykeg/bin/sound_server.py',
-    ],
-    install_requires = [
-      'django >= 1.3',
-      'django-autoslug',
-      'django-bootstrap-form',
-      'django-imagekit >= 2.0',
-      'django-registration',
-      'django-socialregistration >= 0.5.4',
-      'django_extensions',
+DOCLINES = __doc__.split('\n')
 
-      'facebook-sdk >= 0.3.0',
+# Change this to True to include optional dependencies
+USE_OPTIONAL = False
 
-      'MySQL-python',
-      'pil',
-      'protobuf >= 2.4.1',
-      'pylcdui >= 0.5.5',
-      'pysqlite>=2.0.3',
-      'python-gflags >= 1.8',
-      'South >= 0.7.3',
-      'Sphinx',
-      'django_nose',
-      'tweepy',
-      'django-icanhaz',
-      'pytz',
+VERSION = '0.9.0'
+SHORT_DESCRIPTION = DOCLINES[0]
+LONG_DESCRIPTION = '\n'.join(DOCLINES[2:])
+REQUIRED = [
+  'django >= 1.3',
+  'django-autoslug',
+  'django-bootstrap-form',
+  'django-imagekit >= 2.0',
+  'django-registration',
+  'django-socialregistration >= 0.5.4',
+  'django_extensions',
 
-      'requests',  # needed by oauth
-      'poster',  # needed by foursquare
-      'foursquare',
+  'facebook-sdk >= 0.3.0',
 
-      ### Optional modules.
+  'MySQL-python',
+  'pil',
+  'protobuf >= 2.4.1',
+  'pylcdui >= 0.5.5',
+  'pysqlite>=2.0.3',
+  'python-gflags >= 1.8',
+  'South >= 0.7.3',
+  'Sphinx',
+  'django_nose',
+  'tweepy',
+  'django-icanhaz',
+  'pytz',
 
-      # This modules 'pip install'd manually.  If you add to this list, also
-      # update pykeg.core.optional_modules with a new 'HAVE_<MODULE>' flag, as
-      # well as pykeg.settings (if needed).
+  'requests', # needed by oauth
+  'poster', # needed by foursquare
+  'foursquare',
+]
 
-      ### django-debug-toolbar
-      #'django-debug-toolbar',
+OPTIONAL = [
+  ### Optional modules.
+  # This modules 'pip install'd manually.  If you add to this list, also
+  # update pykeg.core.optional_modules with a new 'HAVE_<MODULE>' flag, as
+  # well as pykeg.settings (if needed).
 
-      ### Celery
-      #'Celery',
-      #'django-celery',
-      #'django-kombu',
+  ### django-debug-toolbar
+  'django-debug-toolbar',
 
-      ### Tornado
-      #'tornado',
-      #'rjdj.djangotornado',
+  ### Celery
+  'Celery',
+  'django-celery',
+  'django-kombu',
 
-      ### Raven
-      #'raven',
+  ### Tornado
+  'tornado',
+  'rjdj.djangotornado',
 
-      ### Sentry
-      #'sentry',
-      #'django-sentry',
-    ],
-    dependency_links = [
-        'https://github.com/rem/python-protobuf/tarball/master#egg=protobuf-2.4.1',
-        'https://github.com/tzangms/django-bootstrap-form/tarball/master#egg=django-bootstrap-form',
-        'https://github.com/rjdj/django-tornado/tarball/master#egg=rjdj.djangotornado',
-    ],
-    include_package_data = True,
-    entry_points = {
-      'console_scripts': ['instance=django.core.management:execute_manager'],
-    },
+  ### Raven
+  'raven',
 
-)
+  ### Sentry
+  'sentry',
+  'django-sentry',
+]
+
+DEPENDENCIES = REQUIRED
+if USE_OPTIONAL:
+  DEPENDENCIES += OPTIONAL
+
+
+def setup_package():
+  from distribute_setup import use_setuptools
+  use_setuptools()
+  from setuptools import setup, find_packages
+
+  setup(
+      name = 'kegbot',
+      version = VERSION,
+      description = SHORT_DESCRIPTION,
+      long_description = LONG_DESCRIPTION,
+      author = 'mike wakerly',
+      author_email = 'opensource@hoho.com',
+      url = 'http://kegbot.org/',
+      packages = find_packages('src'),
+      package_dir = {
+        '' : 'src',
+      },
+      scripts = [
+        'distribute_setup.py',
+        'src/pykeg/bin/kegboard_daemon.py',
+        'src/pykeg/bin/kegboard_monitor.py',
+        'src/pykeg/bin/kegboard-tester.py',
+        'src/pykeg/bin/kegbot-admin.py',
+        'src/pykeg/bin/kegbot_core.py',
+        'src/pykeg/bin/kegbot_master.py',
+        'src/pykeg/bin/lcd_daemon.py',
+        'src/pykeg/bin/rfid_daemon.py',
+        'src/pykeg/bin/sound_server.py',
+      ],
+      install_requires = DEPENDENCIES,
+      dependency_links = [
+          'https://github.com/rem/python-protobuf/tarball/master#egg=protobuf-2.4.1',
+          'https://github.com/tzangms/django-bootstrap-form/tarball/master#egg=django-bootstrap-form',
+          'https://github.com/rjdj/django-tornado/tarball/master#egg=rjdj.djangotornado',
+      ],
+      include_package_data = True,
+      entry_points = {
+        'console_scripts': ['instance=django.core.management:execute_manager'],
+      },
+
+  )
+
+if __name__ == '__main__':
+  setup_package()

--- a/pykeg/src/pykeg/settings.py
+++ b/pykeg/src/pykeg/settings.py
@@ -6,6 +6,15 @@
 # Grab flags for optional modules.
 from pykeg.core.optional_modules import *
 
+import os
+import logging
+if (os.getenv('SERVER_SOFTWARE', '').startswith('Google App Engine') or os.getenv('SETTINGS_MODE') == 'prod'):
+  logging.info("Running in AppEngine")
+  APPENGINE = True
+else:
+  logging.info("Running stand alone [%s]", os.getenv('SERVER_SOFTWARE', ''))
+  APPENGINE = False
+
 INSTALLED_APPS = (
     'django.contrib.admin',
     'django.contrib.auth',

--- a/pykeg/src/pykeg/web/wsgi_app.py
+++ b/pykeg/src/pykeg/web/wsgi_app.py
@@ -1,0 +1,19 @@
+'''
+Created on May 11, 2012
+
+@author: shane
+'''
+import os
+
+os.environ['DJANGO_SETTINGS_MODULE'] = 'pykeg.settings'
+
+from google.appengine.ext.webapp import util
+import django.core.handlers.wsgi
+
+app = django.core.handlers.wsgi.WSGIHandler()
+
+def main():
+  util.run_wsgi_app(app)
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
Initial AppEngine support (WIP)
- Added app.yaml and main.py for sunning in GAE.
- Started a Paver setup script to build the environment for GAE.
- Changed setup.py to be includable as a module.
- Updated settings to include a flag for if we are running in AppEngine.

There is still some work to build the complete AppEngine environment since all modules not provided by GAE need to be included and uploaded to the server. The app.yaml also needs to be modified to work better with static files.
