### PR TITLE
Fix: supervisor tasks must not self-daemonize

### DIFF
--- a/deploy/kegbot-supervisor.conf
+++ b/deploy/kegbot-supervisor.conf
@@ -20,7 +20,7 @@ redirect_stderr=true
 
 # Optional install; see docs.
 [program:celery]
-command=/data/kegbot/kb/bin/kegbot-admin.py celeryd_detach -B -E
+command=/data/kegbot/kb/bin/kegbot-admin.py celeryd -B -E
 directory=/data/kegbot
 user=ubuntu
 autostart=true


### PR DESCRIPTION
With the original config, supervisor gets confused when celery self-daemonizes and attempts to relaunch several times, even though celery is already running. Proper fix (according to supervisor docs and my own tests) is to let supervisor daemonize celery instead.
