### PR TITLE
Force django-registration v0.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ DEPENDENCIES = [
 
   'Django >= 1.5,<1.6',
   'django-imagekit == 2.0.2',
-  'django-registration',
+  'django-registration == 0.8',
   'django-socialregistration >= 0.5.10',
   'django-bootstrap-pagination',
 


### PR DESCRIPTION
django-registration v1.0 went through a rewrite that breaks
the current version of pykeg.
