### PR TITLE
Support /usr/local/etc/kegbot as a default settings directory.

### DIFF
--- a/bin/setup-kegbot.py
+++ b/bin/setup-kegbot.py
@@ -262,13 +262,14 @@ class SettingsDir(ConfigurationSetupStep):
   Kegbot's master settings file for this system (local_settings.py) should live
   in one of two places on the filesystem:
 
-    ~/.kegbot/     (local to this user, recommended)
-    /etc/kegbot/   (global to all users, requires root access)
+    ~/.kegbot/            (local to this user, recommended)
+    /etc/kegbot/          (global to all users, requires root access)
+    /usr/local/etc/kegbot (same as above, for FreeBSD)
 
   If in doubt, use the default.
   """
   FLAG = 'settings_dir'
-  CHOICES = ('~/.kegbot', '/etc/kegbot')
+  CHOICES = ('~/.kegbot', '/etc/kegbot', '/usr/local/etc/kegbot')
 
   def validate(self, ctx):
     self.value = os.path.expanduser(self.value)

--- a/deploy/kegweb.wsgi
+++ b/deploy/kegweb.wsgi
@@ -38,11 +38,12 @@ import os, site, sys
 VIRTUAL_ENV = '/path/to/virtualenv/kb'
 
 # The local_settings.py config needs to be on the PATH as well. By default,
-# kegbot looks in # $HOME/.kegbot and /etc/kegbot.  Only change this if you are
-# doing something different.
+# kegbot looks in # $HOME/.kegbot, /etc/kegbot and /usr/local/etc/kegbot.  
+# Only change this if you are doing something different.
 EXTRA_PATHS = [
     os.path.join(os.environ.get('HOME'), '.kegbot'),
     '/etc/kegbot',
+    '/usr/local/etc/kegbot',
 ]
 
 ### Main script -- should not need to edit past here.

--- a/deploy/local_settings.py.example
+++ b/deploy/local_settings.py.example
@@ -1,6 +1,6 @@
 # Local settings for kegbot.
-# Edit settings, then copy this file to /etc/kegbot/local_settings.py or
-# ~/.kegbot/local_settings.py
+# Edit settings, then copy this file to /etc/kegbot/local_settings.py,
+# /usr/local/etc/kegbot or ~/.kegbot/local_settings.py
 
 # Disable DEBUG mode when serving external traffic.
 DEBUG = True

--- a/pykeg/core/kb_common.py
+++ b/pykeg/core/kb_common.py
@@ -2,6 +2,7 @@
 LOCAL_SETTINGS_SEARCH_DIRS = (
     '~/.kegbot/',
     '/etc/kegbot/',
+    '/usr/local/etc/kegbot',
 )
 
 ### Drink-related constants


### PR DESCRIPTION
FreeBSD mandates that all non-base configuration files live in
`/usr/local/etc` rather than `/etc` (which is reserved for OS-level
configuration). This commit adds support for `/usr/local/etc/kegbot` as
a default configuration directory so that kegbot works more cleanly on
FreeBSD.

:heart:
