### PR TITLE
User can delete owned photos from drink page

### DIFF
--- a/pykeg/web/kegweb/templates/kegweb/drink_detail.html
+++ b/pykeg/web/kegweb/templates/kegweb/drink_detail.html
@@ -56,6 +56,29 @@
 </div>
 {% endif %}
 
+{% ifequal user.username drink.user.username %}
+<div class="modal fade" id="confirmDelete" role="dialog" aria-labelledby="confirmDeleteLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+        <h4 class="modal-title">Delete Photo?</h4>
+      </div>
+      <div class="modal-body">
+        <p>Are you sure you want to delete this photo?</p>
+      </div>
+      <div class="modal-footer">
+        <form action="{% url 'kb-drink' drink.id %}" method="POST">{% csrf_token %}
+          <input type="hidden" name="requestor_name" value="{{ user.username }}">
+          <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+          <button type="submit" class="btn btn-danger" name="confirm_delete_photo">Delete</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endifequal %}
+
 <div class="row-fluid">
 
 <div class="span6">
@@ -150,6 +173,12 @@
 <div class="span6">
   {% if drink.picture %}
   <img src="{{ drink.picture.resized.url }}">
+    {% ifequal user.username drink.user.username %}
+    <div style="margin-top:-15px;position:relative;">
+      <button class="btn btn-xs btn-danger pull-right" type="button" data-toggle="modal" data-target="#confirmDelete" data-title="Delete Photo" data-message="Are you sure you want to delete this photo?">
+          <i class="icon-trash icon-white"></i></button>
+    </div>
+    {% endifequal %}
   {% endif %}
   {% if drink.shout %}
     {% include 'kegweb/includes/drink_shout.html' %}

--- a/pykeg/web/kegweb/views.py
+++ b/pykeg/web/kegweb/views.py
@@ -30,6 +30,7 @@ from django.views.generic.dates import MonthArchiveView
 from django.views.generic.dates import YearArchiveView
 from django.views.generic.list import ListView
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
+from django.core.files.storage import get_storage_class
 
 from kegbot.util import kbjson
 
@@ -139,6 +140,14 @@ def short_session_detail(request, session_id):
 
 def drink_detail(request, drink_id):
     drink = get_object_or_404(models.Drink, id=drink_id)
+    if request.method == 'POST':
+        if 'confirm_delete_photo' in request.POST:
+            requestor_name = request.POST['requestor_name']
+            if requestor_name == drink.user.username:
+                storage = get_storage_class()()
+                storage.delete(drink.picture.image)
+                drink.picture.delete()
+                return redirect('kb-drink', drink_id=str(drink_id))
     context = RequestContext(request, {'drink': drink})
     return render_to_response('kegweb/drink_detail.html', context_instance=context)
 


### PR DESCRIPTION
I tried doing this a number of ways, but the most elegant solution is to do it from one location - the drink page.  Only the user who owns the drink tied to the photo can delete it.

There were too many 'trash' icons littered across the UI if we try to do this from wherever the images exist.  If we decide to go that route, the backend will be much more elegant when we migrate to Bootstrap 3 (cancel confirmation modals for multiple items on a single page is baked-in).
