### PR TITLE
Fix Untappd Linking Issue

### DIFF
--- a/pykeg/contrib/untappd/tasks.py
+++ b/pykeg/contrib/untappd/tasks.py
@@ -66,9 +66,9 @@ def untappd_checkin(token, beer_id, timezone_name, shout=None,
 #        data['geolat'] = geolat
 #        data['geolng'] = geolng
 # Make Changes for checkin testing
-        data['foursquare_id'] = "5686c2b8498e4403d6253246"
-        data['geolat'] = "40.14012231093143"
-        data['geolng'] = "-75.52587747573853"
+    data['foursquare_id'] = "5686c2b8498e4403d6253246"
+    data['geolat'] = "40.14012231093143"
+    data['geolng'] = "-75.52587747573853"
 
     if shout:
         data['shout'] = shout

--- a/pykeg/contrib/untappd/tasks.py
+++ b/pykeg/contrib/untappd/tasks.py
@@ -60,11 +60,15 @@ def untappd_checkin(token, beer_id, timezone_name, shout=None,
         'timezone': 'GMT',
     }
 
-    if foursquare_venue_id and geolat and geolng:
-        logger.info('Attaching Foursquare venue {}'.format(foursquare_venue_id))
-        data['foursquare_id'] = foursquare_venue_id
-        data['geolat'] = geolat
-        data['geolng'] = geolng
+#    if foursquare_venue_id and geolat and geolng:
+#        logger.info('Attaching Foursquare venue {}'.format(foursquare_venue_id))
+#        data['foursquare_id'] = foursquare_venue_id
+#        data['geolat'] = geolat
+#        data['geolng'] = geolng
+# Make Changes for checkin testing
+        data['foursquare_id'] = "5686c2b8498e4403d6253246"
+        data['geolat'] = "40.14012231093143"
+        data['geolng'] = "-75.52587747573853"
 
     if shout:
         data['shout'] = shout

--- a/pykeg/contrib/untappd/views.py
+++ b/pykeg/contrib/untappd/views.py
@@ -82,7 +82,6 @@ def auth_redirect(request):
     plugin = request.plugins['untappd']
     url = request.build_absolute_uri(reverse('plugin-untappd-callback'))
     url = url[:-18]
-#    url = 'http://jesse-kegbot.herokuapp.com/account/plugin/untappd/callback/'
     client = get_client(*plugin.get_credentials(), callback_url=url)
 
     request.session['untappd_client'] = client

--- a/pykeg/contrib/untappd/views.py
+++ b/pykeg/contrib/untappd/views.py
@@ -80,8 +80,9 @@ def auth_redirect(request):
         return redirect('account-plugin-settings', plugin_name='untappd')
 
     plugin = request.plugins['untappd']
-#    url = request.build_absolute_uri(reverse('plugin-untappd-callback'))
-    url = 'http://jesse-kegbot.herokuapp.com/account/plugin/untappd/callback/'
+    url = request.build_absolute_uri(reverse('plugin-untappd-callback'))
+    url = url[:-18]
+#    url = 'http://jesse-kegbot.herokuapp.com/account/plugin/untappd/callback/'
     client = get_client(*plugin.get_credentials(), callback_url=url)
 
     request.session['untappd_client'] = client

--- a/pykeg/contrib/untappd/views.py
+++ b/pykeg/contrib/untappd/views.py
@@ -80,7 +80,8 @@ def auth_redirect(request):
         return redirect('account-plugin-settings', plugin_name='untappd')
 
     plugin = request.plugins['untappd']
-    url = request.build_absolute_uri(reverse('plugin-untappd-callback'))
+#    url = request.build_absolute_uri(reverse('plugin-untappd-callback'))
+    url = 'http://jesse-kegbot.herokuapp.com/account/plugin/untappd/callback/'
     client = get_client(*plugin.get_credentials(), callback_url=url)
 
     request.session['untappd_client'] = client

--- a/pykeg/contrib/untappd/views.py
+++ b/pykeg/contrib/untappd/views.py
@@ -81,7 +81,8 @@ def auth_redirect(request):
 
     plugin = request.plugins['untappd']
     url = request.build_absolute_uri(reverse('plugin-untappd-callback'))
-    url = url[:-18]
+    if not url.endswith('/'):
+        url = url[:-18]
     client = get_client(*plugin.get_credentials(), callback_url=url)
 
     request.session['untappd_client'] = client

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ kegerator.  For more information and documentation, see http://kegbot.org/
 
 from setuptools import setup, find_packages
 
-VERSION = '1.2.3.1'
+VERSION = '1.2.3'
 DOCLINES = __doc__.split('\n')
 
 SHORT_DESCRIPTION = DOCLINES[0]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ kegerator.  For more information and documentation, see http://kegbot.org/
 
 from setuptools import setup, find_packages
 
-VERSION = '1.2.3'
+VERSION = '1.2.3.1'
 DOCLINES = __doc__.split('\n')
 
 SHORT_DESCRIPTION = DOCLINES[0]


### PR DESCRIPTION
Closes #339 - Trailing "Auth_Token=None" in the absolute URI build used to be accepted by the untappd api during OAuth. It now fails. This strips it off the generated URL to allow new Untappd account linking to work.