### PR TITLE
Don't require user to be active in order to view the user's details and sessions.

### DIFF
--- a/pykeg/web/kegweb/views.py
+++ b/pykeg/web/kegweb/views.py
@@ -88,7 +88,7 @@ def system_stats(request):
 ### object lists and detail (generic views)
 
 def user_detail(request, username):
-    user = get_object_or_404(models.User, username=username, is_active=True)
+    user = get_object_or_404(models.User, username=username)
     stats = user.get_stats()
     drinks = user.drinks.all()
 
@@ -177,7 +177,7 @@ def drink_detail(request, drink_id):
 
 
 def drinker_sessions(request, username):
-    user = get_object_or_404(models.User, username=username, is_active=True)
+    user = get_object_or_404(models.User, username=username)
     stats = user.get_stats()
     drinks = user.drinks.all()
 


### PR DESCRIPTION
If a user has been deactivated, attempting to view the user's details or sessions results in error 404.
It's nice to be able to deactivate a user so that they don't show in the android apps user list, log in, etc. However, this ruins the fun of viewing past sessions and such.
This change allows user details and sessions to be viewable for deactivated users.