### PR TITLE
Fixed keg list error

### DIFF
--- a/pykeg/core/models.py
+++ b/pykeg/core/models.py
@@ -774,8 +774,8 @@ class Keg(models.Model):
         return self.get_illustration(thumbnail=True)
 
     def get_sessions(self):
-        sessions_ids = Drink.objects.filter(keg=self.id).values('session').annotate(models.Count('id'))
-        pks = [x.get('session') for x in sessions_ids]
+        sessions_ids = Drink.objects.filter(keg=self.id).values('session_id').annotate(id=models.Count('id'), time=models.Count('time'))
+        pks = [x.get('session_id') for x in sessions_ids]
         return [DrinkingSession.objects.get(pk=pk) for pk in pks]
 
     def get_top_users(self):


### PR DESCRIPTION
Addresses the "...which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by" error returned on the keglist page which you can see when clicking on a tap on the main page