### PR TITLE
Update variable name to make this compatible with MySQL versions later than v5.7.5

### DIFF
--- a/bin/setup-kegbot.py
+++ b/bin/setup-kegbot.py
@@ -366,7 +366,7 @@ class ConfigureDatabase(ConfigurationSetupStep):
     }
     if self.choice == 'mysql':
       cfg['default']['ENGINE'] = 'django.db.backends.mysql'
-      cfg['default']['OPTIONS'] = { 'init_command': 'SET storage_engine=INNODB' }
+      cfg['default']['OPTIONS'] = { 'init_command': 'SET default_storage_engine=INNODB' }
     else:
       cfg['default']['ENGINE'] = 'django.db.backends.postgresql_psycopg2'
 


### PR DESCRIPTION
storage_engine has been replaced with default_storage_engine in MySQL, deprecated as of v5.7.5.
When following the Install Guide, the recommended Homebrew method installed mysql v5.7.14 (in September 2016), so I suspect this will be a common problem for anyone trying kegbot setup from now on.

[Documentation about mysql storage_engine variable](http://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_storage_engine2)

[Kegbot Forum discussion about this issue](https://forum.kegbot.org/t/installing-kegbot-server-on-mac-storage-engine-error/755)