### PR TITLE
gitignore common virtualenv names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ docs/build
 ### pykeg
 build
 dist
+
+### various virtualenv names
+venv
+env
+kb


### PR DESCRIPTION
I went to get started fixing some issues in kegbot and found that there was no good place to put my virtualenv. This just adds two common virtualenv folder names to `.gitignore`