### PR TITLE
Fix: admin drink deletions not updating stats/sessions

### DIFF
--- a/docs/source/release-notes/changelog.rst
+++ b/docs/source/release-notes/changelog.rst
@@ -40,6 +40,7 @@ For a detailed look at what's new in version 1.3, see :ref:`version-13-release-n
 * Skip notifications for inactive users  (#349)
 * Fix compatibility with with MySQL versions later than v5.7.5 (#356)
 * Allow usernames with a period (#336)
+* Update stats and sessions when admin deletes a drink (#371)
 
 **Other Changes**
 

--- a/pykeg/web/kegadmin/views.py
+++ b/pykeg/web/kegadmin/views.py
@@ -669,7 +669,7 @@ def drink_list(request):
             delete_ids = request.POST.getlist("delete_ids[]")
             drinks = models.Drink.objects.filter(Q(id__in=delete_ids))
             for drink in drinks:
-                drink.delete()
+                request.backend.cancel_drink(drink)
             delete_ids.reverse()
             if len(delete_ids) == 1:
                 messages.success(request, 'Drink ' + delete_ids[0] + ' has been deleted.')


### PR DESCRIPTION
Closes #371.
Closes #372.