### PR TITLE
Add docker build Github Action

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,0 +1,11 @@
+name: Docker Build
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag kegbot-server:${GITHUB_SHA::8}


### PR DESCRIPTION
Runs `docker build` on repo push. Only verifies build, does not (yet) push artifacts to docker hub.

Part of issue #389