### PR TITLE
Make initial setup & upgrade easier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,5 @@ EXPOSE 8000
 CMD [ \
    "gunicorn", \
    "pykeg.web.wsgi:application", \
-   "--worker-class=gevent", \
-   "--workers=8", \
-   "--worker-tmp-dir=/dev/shm", \
-   "-b", \
-   "0.0.0.0:8000" \
+   "--config=python:pykeg.web.gunicorn_conf" \
 ]

--- a/pykeg/settings.py
+++ b/pykeg/settings.py
@@ -246,7 +246,7 @@ LOGGING = {
             'propagate': False,
         },
         'django': {
-            'level': 'DEBUG' if DEBUG else 'WARNING',
+            'level': 'INFO' if DEBUG else 'WARNING',
             'handlers': ['console', 'redis'],
             'propagate': False,
         },

--- a/pykeg/util/dbstatus.py
+++ b/pykeg/util/dbstatus.py
@@ -1,0 +1,32 @@
+"""Wraps some common database problems in usable errors."""
+
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+
+
+class DatabaseStatusError(Exception):
+    """General error thrown when the database is... Not Good."""
+
+
+class DatabaseNotInitialized(DatabaseStatusError):
+    """Thrown when the db doesn't appear to be initialized."""
+
+
+class NeedMigration(DatabaseStatusError):
+    """Thrown when a migration is needed."""
+    def __init__(self, migration_name):
+        super(NeedMigration, self).__init__('Migration "{}" not applied'.format(migration_name))
+        self.migration_name = migration_name
+
+
+def check_db_status():
+    tables = connection.introspection.table_names()
+    if 'django_migrations' not in tables:
+        raise DatabaseNotInitialized()
+
+    executor = MigrationExecutor(connection)
+    targets = executor.loader.graph.leaf_nodes()
+    plan = executor.migration_plan(targets)
+    if plan:
+        migration = plan[0][0]
+        raise NeedMigration(migration.name)

--- a/pykeg/web/gunicorn_conf.py
+++ b/pykeg/web/gunicorn_conf.py
@@ -1,0 +1,28 @@
+import multiprocessing
+import pkg_resources
+import sys
+
+BANNER = """
+██╗  ██╗███████╗ ██████╗ ██████╗  ██████╗ ████████╗
+██║ ██╔╝██╔════╝██╔════╝ ██╔══██╗██╔═══██╗╚══██╔══╝
+█████╔╝ █████╗  ██║  ███╗██████╔╝██║   ██║   ██║   
+██╔═██╗ ██╔══╝  ██║   ██║██╔══██╗██║   ██║   ██║   
+██║  ██╗███████╗╚██████╔╝██████╔╝╚██████╔╝   ██║   
+╚═╝  ╚═╝╚══════╝ ╚═════╝ ╚═════╝  ╚═════╝    ╚═╝   
+""".strip()
+
+def get_version():
+    try:
+        return pkg_resources.get_distribution('kegbot').version
+    except pkg_resources.DistributionNotFound:
+        return '0.0.0'
+
+bind = "0.0.0.0:8000"
+worker_class = "gevent"
+workers = multiprocessing.cpu_count() * 2 + 1
+
+print(BANNER, file=sys.stderr)
+print('kegbot-server - version {}'.format(get_version()), file=sys.stderr)
+print('  homepage: https://kegbot.org', file=sys.stderr)
+print('   discuss: https://forum.kegbot.org', file=sys.stderr)
+print('-' * 80, file=sys.stderr)

--- a/pykeg/web/middleware.py
+++ b/pykeg/web/middleware.py
@@ -24,6 +24,7 @@ from pykeg import config
 from pykeg.core.util import get_version_object
 from pykeg.core.util import set_current_request
 from pykeg.core.util import must_upgrade
+from pykeg.util import dbstatus
 from pykeg.web.api.util import is_api_request
 
 from pykeg.plugin import util as plugin_util
@@ -73,24 +74,7 @@ class CurrentRequestMiddleware(object):
 
 
 class IsSetupMiddleware(object):
-    def __init__(self, get_response):
-        self.get_response = get_response
-
-    def __call__(self, request):
-        if not config.is_setup():
-            # Disable the auth user middleware.
-            request.session = {}
-            request.session['_auth_user_backend'] = None
-
-            if not request.path.startswith('/setup'):
-                return render(request, 'setup_wizard/setup_required.html', status=403)
-        return self.get_response(request)
-
-
-class KegbotSiteMiddleware(object):
-    ALLOWED_VIEW_MODULE_PREFIXES = (
-        'pykeg.web.setup_wizard.',
-    )
+    """Adds `.need_setup`, `.need_upgrade`, and `.kbsite` to the request."""
 
     def __init__(self, get_response):
         self.get_response = get_response
@@ -100,30 +84,45 @@ class KegbotSiteMiddleware(object):
         request.need_upgrade = False
         request.kbsite = None
 
-        installed_version = models.KegbotSite.get_installed_version()
-        if installed_version is None:
-            request.need_setup = True
-        else:
-            request.installed_version_string = str(installed_version)
-            request.need_upgrade = must_upgrade(installed_version, get_version_object())
+        # Skip all checks if we're in the setup wizard.
+        if request.path.startswith('/setup'):
+            request.session = {}
+            request.session['_auth_user_backend'] = None
+            return self.get_response(request)
 
-        if not request.need_setup and not request.need_upgrade:
-            request.kbsite = models.KegbotSite.objects.get(name='default')
-            if request.kbsite.is_setup:
-                timezone.activate(request.kbsite.timezone)
-                request.plugins = dict((p.get_short_name(), p)
-                                       for p in list(plugin_util.get_plugins().values()))
-            else:
+        # First confirm the database is working.
+        try:
+            dbstatus.check_db_status()
+        except dbstatus.DatabaseNotInitialized:
+            logger.warning('Database is not initialized, sending to setup ...')
+            request.need_setup = True
+            request.need_upgrade = True
+        except dbstatus.NeedMigration:
+            logger.warning('Database needs migration, sending to setup ...')
+            request.need_upgrade = True
+        
+        # If the database looks good, check the data.
+        if not request.need_setup:
+            installed_version = models.KegbotSite.get_installed_version()
+            if installed_version is None:
+                logger.warning('Kegbot not installed, sending to setup ...')
                 request.need_setup = True
-            request.backend = get_kegbot_backend()
+            else:
+                request.installed_version_string = str(installed_version)
+                if must_upgrade(installed_version, get_version_object()):
+                    logger.warning('Kegbot upgrade required, sending to setup ...')
+                    request.need_setup = True
+        
+        # Lastly verify the kbsite record.
+        if not request.need_setup:
+            request.kbsite = models.KegbotSite.objects.get(name='default')
+            if not request.kbsite.is_setup:
+                logger.warning('Setup incomplete, sending to setup ...')
+                request.need_setup = True
 
         return self.get_response(request)
 
     def process_view(self, request, view_func, view_args, view_kwargs):
-        for prefix in self.ALLOWED_VIEW_MODULE_PREFIXES:
-            if view_func.__module__.startswith(prefix):
-                return None
-
         if is_api_request(request):
             # API endpoints handle "setup required" differently.
             return None
@@ -144,6 +143,20 @@ class KegbotSiteMiddleware(object):
         }
         return render(request, 'setup_wizard/upgrade_required.html',
                       context=context, status=403)
+
+
+class KegbotSiteMiddleware(object):
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.kbsite and not request.need_setup:
+            timezone.activate(request.kbsite.timezone)
+            request.plugins = dict((p.get_short_name(), p)
+                                    for p in list(plugin_util.get_plugins().values()))
+            request.backend = get_kegbot_backend()
+
+        return self.get_response(request)
 
 
 class PrivacyMiddleware(object):

--- a/pykeg/web/middleware.py
+++ b/pykeg/web/middleware.py
@@ -111,7 +111,7 @@ class IsSetupMiddleware(object):
                 request.installed_version_string = str(installed_version)
                 if must_upgrade(installed_version, get_version_object()):
                     logger.warning('Kegbot upgrade required, sending to setup ...')
-                    request.need_setup = True
+                    request.need_upgrade = True
         
         # Lastly verify the kbsite record.
         if not request.need_setup:

--- a/pykeg/web/setup_wizard/templates/setup_wizard/base.html
+++ b/pykeg/web/setup_wizard/templates/setup_wizard/base.html
@@ -70,5 +70,18 @@
 {% block content %}
 {% endblock %}
 
+{% if error_stack %}
+<div class="container">
+  <div class="row-fluid">
+    <div class="span10">
+      <hr/>
+      <h3>Error logs</h3>
+      {% if error_message %}<h5>{{ error_message }}{% endif %}
+      <pre>{{ error_stack }}</pre>
+    </div>
+  </div>
+</div>
+{% endif %}
+
 </div> <!-- /container-narrow -->
 {% endblock body %}

--- a/pykeg/web/setup_wizard/templates/setup_wizard/finish.html
+++ b/pykeg/web/setup_wizard/templates/setup_wizard/finish.html
@@ -11,8 +11,8 @@
 </p>
 
 <p>
-  Now would also be a good time to set <code>DEBUG = False</code> in your
-  <code>local_settings.py</code>.
+  Now would also be a good time to set <code>KEGBOT_ENV=production</code> in your
+  settings.
 </p>
 
 <p/>

--- a/pykeg/web/setup_wizard/templates/setup_wizard/mode.html
+++ b/pykeg/web/setup_wizard/templates/setup_wizard/mode.html
@@ -1,0 +1,37 @@
+{% extends "setup_wizard/base.html" %}
+{% load crispy_forms_tags %}
+
+{% block content %}
+<div class="jumbotron">
+
+<h2>Kegbot Setup: Pick Mode</h2>
+<p class="lead">
+  Before you continue, what kind of Kegbot would you like?<br/>
+  (You can always change settings later.)
+</p>
+
+<div class="row-fluid">
+  <div class="span8 offset2">
+    <form action="" method="POST">{% csrf_token %}
+
+      <p>
+        <input type="submit" name="enable_sensing" value="Enable Sensors, Continue »"
+            class="btn btn-primary btn-success btn-block" id="submit-id-enable_sensing">
+        <span class="muted">Classic mode: Enables features that require flow sensing hardware.</span>
+      </p>
+      
+      <br/>
+      
+      <p>
+        <input type="submit" name="disable_sensing" value="No Sensor Hardware, Continue »"
+            class="btn btn-primary btn-info btn-block" id="submit-id-disable_sensing">
+        <span class="muted">Hides features that require flow sensing hardware.</span>
+      </p>
+
+    </form>
+  </div>
+</div>
+
+</div>
+
+{% endblock content %}

--- a/pykeg/web/setup_wizard/templates/setup_wizard/start.html
+++ b/pykeg/web/setup_wizard/templates/setup_wizard/start.html
@@ -6,8 +6,13 @@
 
 <h2>Kegbot Setup: Welcome</h2>
 <p class="lead">
-  Before you get started, what kind of Kegbot would you like?<br/>
-  (You can always change settings later.)
+  {% if need_upgrade %}
+  Before you continue, please click below to upgrade your database.
+  {% elif need_install %}
+  Before you continue, please click below to perform database setup.
+  {% else %}
+  Please click below to continue with setup.
+  {% endif %}
 </p>
 
 <div class="row-fluid">
@@ -15,23 +20,14 @@
     <form action="" method="POST">{% csrf_token %}
 
       <p>
-        <input type="submit" name="enable_sensing" value="Enable Sensors, Continue »"
-            class="btn btn-primary btn-success btn-block" id="submit-id-enable_sensing">
-        <span class="muted">Classic mode: Enables features that require flow sensing hardware.</span>
-      </p>
-      
-      <br/>
-      
-      <p>
-        <input type="submit" name="disable_sensing" value="No Sensor Hardware, Continue »"
-            class="btn btn-primary btn-info btn-block" id="submit-id-disable_sensing">
-        <span class="muted">Hides features that require flow sensing hardware.</span>
+        <input type="submit" name="db"
+          value="{% if need_install %}Install Database{% elif need_upgrade %}Upgrade Database{% else %}Continue{% endif %}"
+            class="btn btn-primary btn-success btn-block" id="submit-id-db">
       </p>
 
     </form>
   </div>
 </div>
-
 </div>
 
 {% endblock content %}

--- a/pykeg/web/setup_wizard/templates/setup_wizard/upgrade.html
+++ b/pykeg/web/setup_wizard/templates/setup_wizard/upgrade.html
@@ -1,0 +1,29 @@
+{% extends "setup_wizard/base.html" %}
+{% load crispy_forms_tags %}
+
+{% block content %}
+<div class="jumbotron">
+
+<h2>Upgrade Kegbot</h2>
+<p class="lead">
+  {% if message %}
+    {{ message }}
+  {% else %}
+    Please click below to upgrade your Kegbot.
+  {% endif %}
+</p>
+
+<div class="row-fluid">
+  <div class="span8 offset2">
+    <form action="" method="POST">{% csrf_token %}
+      <p>
+        <input type="submit" name="update_db" value="Upgrade"
+            class="btn btn-primary btn-success btn-block" id="submit-id-update_db">
+      </p>
+    </form>
+  </div>
+</div>
+
+</div>
+
+{% endblock content %}

--- a/pykeg/web/setup_wizard/urls.py
+++ b/pykeg/web/setup_wizard/urls.py
@@ -22,6 +22,8 @@ from pykeg.web.setup_wizard import views
 
 urlpatterns = [
     url(r'^$', views.start, name='setup_wizard_start'),
+    url(r'^upgrade/$', views.upgrade, name='setup_upgrade'),
+    url(r'^mode/$', views.mode, name='setup_mode'),
     url(r'^setup-accounts/$', views.setup_accounts, name='setup_accounts'),
     url(r'^settings/$', views.site_settings, name='setup_site_settings'),
     url(r'^admin-user/$', views.admin, name='setup_admin'),

--- a/pykeg/web/setup_wizard/views.py
+++ b/pykeg/web/setup_wizard/views.py
@@ -17,10 +17,12 @@
 # along with Pykeg.  If not, see <http://www.gnu.org/licenses/>.
 
 from functools import wraps
+import logging
+import traceback
 from django.conf import settings
+from django.core import management
 from django.contrib import messages
 from django.contrib.auth import authenticate
-from django.contrib.auth import login
 from django.http import Http404
 from django.shortcuts import redirect
 from django.shortcuts import render
@@ -28,9 +30,13 @@ from django.views.decorators.cache import never_cache
 
 from pykeg.core import defaults
 from pykeg.core import models
+from pykeg.util import dbstatus
+from pykeg.core.util import get_version_object
 
 from .forms import AdminUserForm
 from .forms import MiniSiteSettingsForm
+
+logger = logging.getLogger(__name__)
 
 
 def setup_view(f):
@@ -48,21 +54,79 @@ def setup_view(f):
 @setup_view
 @never_cache
 def start(request):
-    """ Shows the enable/disable hardware toggle. """
+    """Shows database setup button"""
+    context = {}
+
+    if request.method == 'POST':
+        try:
+            management.call_command("migrate", no_input=True)
+            return redirect('setup_mode')
+        except Exception as e:
+            logger.exception('Error installing database')
+            context['error_message'] = str(e)
+            context['error_stack'] = traceback.format_exc()
+    else:
+        try:
+            logger.info('Checking database status ...')
+            dbstatus.check_db_status()
+            logger.info('Database status OK.')
+        except dbstatus.DatabaseNotInitialized:
+            context['need_install'] = True
+        except dbstatus.NeedMigration:
+            context['need_upgrade'] = True
+
+    return render(request, 'setup_wizard/start.html', context=context)
+
+
+@setup_view
+@never_cache
+def mode(request):
+    """Shows the enable/disable hardware toggle."""
     context = {}
 
     if request.method == 'POST':
         if 'enable_sensing' in request.POST:
-            request.session['enable_sensing'] = True
-            return redirect('setup_accounts')
+            response = redirect('setup_accounts')
+            response.set_cookie('kb_setup_enable_sensing', 'True')
+            return response
         elif 'disable_sensing' in request.POST:
-            request.session['enable_sensing'] = False
-            request.session['enable_users'] = False
-            return redirect('setup_site_settings')
+            response = redirect('setup_site_settings')
+            response.set_cookie('kb_setup_enable_sensing', 'False')
+            response.set_cookie('kb_setup_enable_users', 'False')
+            return response
         else:
             messages.error(request, 'Unknown response.')
 
-    return render(request, 'setup_wizard/start.html', context=context)
+    return render(request, 'setup_wizard/mode.html', context=context)
+
+
+@setup_view
+@never_cache
+def upgrade(request):
+    context = {}
+    if request.method == 'POST':
+        try:
+            management.call_command("migrate", no_input=True)
+            site = models.KegbotSite.get()
+            app_version = get_version_object()
+            site.server_version = str(app_version)
+            site.save()
+            return redirect('kb-home')
+        except Exception as e:
+            logger.exception('Error installing database')
+            context['error_message'] = str(e)
+            context['error_stack'] = traceback.format_exc()
+
+    try:
+        logger.info('Checking database status ...')
+        dbstatus.check_db_status()
+        logger.info('Database status OK.')
+    except dbstatus.DatabaseNotInitialized:
+        context['message'] = 'Database not initialized'
+    except dbstatus.NeedMigration:
+        context['message'] = 'Database upgrade needed'
+
+    return render(request, 'setup_wizard/upgrade.html', context=context)
 
 
 @setup_view
@@ -73,11 +137,13 @@ def setup_accounts(request):
 
     if request.method == 'POST':
         if 'enable_users' in request.POST:
-            request.session['enable_users'] = True
-            return redirect('setup_site_settings')
+            response = redirect('setup_site_settings')
+            response.set_cookie('kb_setup_enable_users', 'True')
+            return response
         elif 'disable_users' in request.POST:
-            request.session['enable_users'] = False
-            return redirect('setup_site_settings')
+            response = redirect('setup_site_settings')
+            response.set_cookie('kb_setup_enable_users', 'False')
+            return response
         else:
             messages.error(request, 'Unknown response.')
 
@@ -90,7 +156,8 @@ def site_settings(request):
     context = {}
 
     if request.method == 'POST':
-        form = MiniSiteSettingsForm(request.POST, instance=request.kbsite)
+        site = models.KegbotSite.get()
+        form = MiniSiteSettingsForm(request.POST, instance=site)
         if form.is_valid():
             form.save()
             messages.success(request, 'Settings saved!')
@@ -102,8 +169,8 @@ def site_settings(request):
             pass
 
         site = models.KegbotSite.get()
-        site.enable_sensing = request.session['enable_sensing']
-        site.enable_users = request.session['enable_users']
+        site.enable_sensing = request.COOKIES.get('kb_setup_enable_sensing') == 'True'
+        site.enable_users = request.COOKIES.get('kb_setup_enable_users') == 'True'
         site.save()
         form = MiniSiteSettingsForm(instance=site)
     context['form'] = form
@@ -121,8 +188,6 @@ def admin(request):
             form.save()
             user = authenticate(username=form.cleaned_data.get('username'),
                                 password=form.cleaned_data.get('password'))
-            if user:
-                login(request, user)
             return redirect('setup_finish')
     context['form'] = form
     return render(request, 'setup_wizard/admin.html', context=context)
@@ -133,8 +198,9 @@ def admin(request):
 def finish(request):
     context = {}
     if request.method == 'POST':
-        request.kbsite.is_setup = True
-        request.kbsite.save()
+        site = models.KegbotSite.get()
+        site.is_setup = True
+        site.save()
         messages.success(request, 'Tip: Install a new Keg in Admin: Taps')
-        return redirect('kegadmin-main')
+        return redirect('kb-home')
     return render(request, 'setup_wizard/finish.html', context=context)

--- a/pykeg/web/templates/skel.html
+++ b/pykeg/web/templates/skel.html
@@ -147,7 +147,7 @@
   });
 </script>
 
-{% if user.is_staff %}
+{% if kbsite and kbsite.is_setup and user.is_staff %}
 {% include 'kegadmin/includes/extrajs.html' %}
 {% endif %}
 

--- a/pykeg/web/wsgi.py
+++ b/pykeg/web/wsgi.py
@@ -9,22 +9,6 @@ https://docs.djangoproject.com/en/1.7/howto/deployment/wsgi/
 
 import os
 from django.core.wsgi import get_wsgi_application
-from pykeg.core.util import get_version
-
-BANNER = """
-██╗  ██╗███████╗ ██████╗ ██████╗  ██████╗ ████████╗
-██║ ██╔╝██╔════╝██╔════╝ ██╔══██╗██╔═══██╗╚══██╔══╝
-█████╔╝ █████╗  ██║  ███╗██████╔╝██║   ██║   ██║   
-██╔═██╗ ██╔══╝  ██║   ██║██╔══██╗██║   ██║   ██║   
-██║  ██╗███████╗╚██████╔╝██████╔╝╚██████╔╝   ██║   
-╚═╝  ╚═╝╚══════╝ ╚═════╝ ╚═════╝  ╚═════╝    ╚═╝   
-""".strip()
-
-print(BANNER)
-print('kegbot-server - version {}'.format(get_version()))
-print('  homepage: https://kegbot.org')
-print('   discuss: https://forum.kegbot.org')
-print('-' * 80)
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pykeg.settings")
 application = get_wsgi_application()


### PR DESCRIPTION
The "is setup" middleware can now detect when tables haven't been installed, or when migrations are needed, and send the user over to the UI to process them.

This should make a clean `docker-compose up`, or similarly fresh setup, able to bootstrap itself.