### PR TITLE
Add API endpoints to add remove tap temp sensors

### DIFF
--- a/pykeg/backend/backends.py
+++ b/pykeg/backend/backends.py
@@ -656,6 +656,21 @@ class KegbotBackend(object):
 
         return tap
 
+    @transaction.atomic
+    def connect_thermo(self, tap, new_thermo):
+        tap = self._get_tap(tap)
+        old_thermo = tap.temperature_sensor
+
+        if old_thermo != new_thermo:
+            if old_thermo:
+                tap.temperature_sensor = None
+                tap.save()
+            if new_thermo:
+                tap.temperature_sensor = new_thermo
+                tap.save()
+
+        return tap
+
     def build_stats(self, drink_id):
         """Build statistics for the given drink (or drink), without adjusting
         any future statistics.

--- a/pykeg/backend/backends.py
+++ b/pykeg/backend/backends.py
@@ -659,15 +659,11 @@ class KegbotBackend(object):
     @transaction.atomic
     def connect_thermo(self, tap, new_thermo):
         tap = self._get_tap(tap)
-        old_thermo = tap.temperature_sensor
-
-        if old_thermo != new_thermo:
-            if old_thermo:
-                tap.temperature_sensor = None
-                tap.save()
-            if new_thermo:
-                tap.temperature_sensor = new_thermo
-                tap.save()
+        if new_thermo:
+            tap.temperature_sensor = new_thermo
+        else:
+            tap.temperature_sensor = None
+        tap.save()
 
         return tap
 

--- a/pykeg/web/api/forms.py
+++ b/pykeg/web/api/forms.py
@@ -6,6 +6,7 @@ from pykeg.core.kb_common import USERNAME_REGEX
 
 ALL_METERS = models.FlowMeter.objects.all()
 ALL_TOGGLES = models.FlowToggle.objects.all()
+ALL_THERMOS = models.ThermoSensor.objects.all()
 
 
 class DrinkPostForm(forms.Form):
@@ -76,3 +77,6 @@ class ConnectMeterForm(forms.Form):
 
 class ConnectToggleForm(forms.Form):
     toggle = forms.ModelChoiceField(queryset=ALL_TOGGLES, required=True)
+
+class ConnectThermoForm(forms.Form):
+    thermo = forms.ModelChoiceField(queryset=ALL_THERMOS, required=True)

--- a/pykeg/web/api/urls.py
+++ b/pykeg/web/api/urls.py
@@ -55,6 +55,8 @@ urlpatterns = [
     url(r"^thermo-sensors/?$", views.all_thermo_sensors),
     url(r"^thermo-sensors/(?P<sensor_name>[^/]+)/?$", views.get_thermo_sensor),
     url(r"^thermo-sensors/(?P<sensor_name>[^/]+)/logs/?$", views.get_thermo_sensor_logs),
+    url(r"^taps/(?P<meter_name_or_id>[\w\.-]+)/connect-thermo/?$", views.tap_connect_thermo),
+    url(r"^taps/(?P<meter_name_or_id>[\w\.-]+)/disconnect-thermo/?$", views.tap_disconnect_thermo),
     url(r"^users/?$", views.user_list),
     url(r"^users/(?P<username>[\w@.+-_]+)/drinks/?$", views.get_user_drinks),
     url(r"^users/(?P<username>[\w@.+-_]+)/events/?$", views.get_user_events),

--- a/pykeg/web/api/views.py
+++ b/pykeg/web/api/views.py
@@ -632,6 +632,27 @@ def tap_disconnect_toggle(request, meter_name_or_id):
     tap = request.backend.connect_toggle(tap, None)
     return protolib.ToProto(tap, full=True)
 
+@require_http_methods(["POST"])
+@csrf_exempt
+@auth_required
+def tap_connect_thermo(request, meter_name_or_id):
+    tap = get_tap_from_meter_name_or_404(meter_name_or_id)
+    form = forms.ConnectThermoForm(request.POST)
+    if form.is_valid():
+        tap = request.backend.connect_thermo(tap, form.cleaned_data["thermo"])
+    else:
+        raise kbapi.BadRequestError(_form_errors(form))
+    return protolib.ToProto(tap, full=True)
+
+
+@require_http_methods(["POST"])
+@csrf_exempt
+@auth_required
+def tap_disconnect_thermo(request, meter_name_or_id):
+    tap = get_tap_from_meter_name_or_404(meter_name_or_id)
+    tap = request.backend.connect_thermo(tap, None)
+    return protolib.ToProto(tap, full=True)
+
 
 @auth_required
 def _tap_detail_post(request, tap):


### PR DESCRIPTION
This PR adds two new API endpoints to allow a user to add/remove a thermo sensor from a tap.

Connect: /api/taps/[tap_id]/connect-thermo (from x-urlencoded form "thermo": [thermo_id])
Disconnect: /api/taps/[tap_id]/disconnect-thermo

This will allows users to select the thermo sensor from the Android app similar to selecting the flow sensor and tap toggle. I have a PR on the Android side to add this selection to the tap settings.