### PR TITLE
Added fixes to get Dockerfile working again.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,19 +10,19 @@ ENV SHELL=/bin/sh \
    KEGBOT_ENV=debug
 
 RUN apk update && \
-    apk add --no-cache \
-      bash \
-      curl \
-      libjpeg \
-      libjpeg-turbo \
-      openjpeg && \
-   pip install pipenv
+   apk add --no-cache \
+   bash \
+   curl \
+   libjpeg \
+   libjpeg-turbo \
+   openjpeg && \
+   pip install pipenv==2018.11.26
 
 ADD Pipfile Pipfile.lock ./
 RUN apk add --no-cache mariadb-connector-c-dev libpq && \
    apk add --no-cache --virtual _build-deps \
-     build-base mariadb-dev postgresql-dev libjpeg-turbo-dev zlib-dev py-gevent libffi-dev && \
-   pipenv install --deploy --system && \
+   build-base mariadb-dev postgresql-dev libjpeg-turbo-dev zlib-dev py-gevent libffi-dev && \
+   pipenv install --deploy --system --skip-lock && \
    apk del _build-deps
 
 ADD bin ./bin
@@ -45,4 +45,4 @@ CMD [ \
    "gunicorn", \
    "pykeg.web.wsgi:application", \
    "--config=python:pykeg.web.gunicorn_conf" \
-]
+   ]


### PR DESCRIPTION
Was getting the following error when trying to run `docker-compose`.  These fixes resolve that.

```
➜  kegbot-server git:(master) docker-compose up
Creating network "kegbot-server_default" with the default driver
Creating volume "kegbot-server_mysql-data" with default driver
Creating volume "kegbot-server_kegbot-data" with default driver
Building kegbot
Step 1/21 : FROM python:3-alpine
3-alpine: Pulling from library/python
801bfaa63ef2: Pull complete
8723b2b92bec: Pull complete
4e07029ccd64: Pull complete
594990504179: Pull complete
140d7fec7322: Pull complete
Digest: sha256:7492c1f615e3651629bd6c61777e9660caa3819cf3561a47d1d526dfeee02cf6
Status: Downloaded newer image for python:3-alpine
 ---> d4d4f50f871a
Step 2/21 : RUN mkdir /app
 ---> Running in 4d0f15d934be
Removing intermediate container 4d0f15d934be
 ---> da53b263f989
Step 3/21 : WORKDIR /app
 ---> Running in 252df2566114
Removing intermediate container 252df2566114
 ---> ecdfc46c4b20
Step 4/21 : ENV SHELL=/bin/sh    PIP_NO_CACHE_DIR=1    KEGBOT_DATA_DIR=/kegbot-data    KEGBOT_IN_DOCKER=True    KEGBOT_ENV=debug
 ---> Running in c43570f05dd1
Removing intermediate container c43570f05dd1
 ---> 2ca689051cf0
Step 5/21 : RUN apk update &&     apk add --no-cache       bash       curl       libjpeg       libjpeg-turbo       openjpeg &&    pip install pipenv
 ---> Running in ff2a3a559ec9
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/x86_64/APKINDEX.tar.gz
v3.12.3-20-g9352de21ca [http://dl-cdn.alpinelinux.org/alpine/v3.12/main]
v3.12.3-19-g600182bf4f [http://dl-cdn.alpinelinux.org/alpine/v3.12/community]
OK: 12746 distinct packages available
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/x86_64/APKINDEX.tar.gz
(1/7) Installing bash (5.0.17-r0)
Executing bash-5.0.17-r0.post-install
(2/7) Installing nghttp2-libs (1.41.0-r0)
(3/7) Installing libcurl (7.69.1-r3)
(4/7) Installing curl (7.69.1-r3)
(5/7) Installing libjpeg-turbo (2.0.5-r0)
(6/7) Installing libjpeg (9d-r0)
(7/7) Installing openjpeg (2.3.1-r6)
Executing busybox-1.31.1-r19.trigger
OK: 18 MiB in 43 packages
Collecting pipenv
  Downloading pipenv-2020.11.15-py2.py3-none-any.whl (3.9 MB)
Requirement already satisfied: setuptools>=36.2.1 in /usr/local/lib/python3.9/site-packages (from pipenv) (51.0.0)
Requirement already satisfied: pip>=18.0 in /usr/local/lib/python3.9/site-packages (from pipenv) (20.3.3)
Collecting virtualenv-clone>=0.2.5
  Downloading virtualenv_clone-0.5.4-py2.py3-none-any.whl (6.6 kB)
Collecting certifi
  Downloading certifi-2020.12.5-py2.py3-none-any.whl (147 kB)
Collecting virtualenv
  Downloading virtualenv-20.2.2-py2.py3-none-any.whl (5.7 MB)
Collecting appdirs<2,>=1.4.3
  Downloading appdirs-1.4.4-py2.py3-none-any.whl (9.6 kB)
Collecting distlib<1,>=0.3.1
  Downloading distlib-0.3.1-py2.py3-none-any.whl (335 kB)
Collecting filelock<4,>=3.0.0
  Downloading filelock-3.0.12-py3-none-any.whl (7.6 kB)
Collecting six<2,>=1.9.0
  Downloading six-1.15.0-py2.py3-none-any.whl (10 kB)
Installing collected packages: six, filelock, distlib, appdirs, virtualenv-clone, virtualenv, certifi, pipenv
Successfully installed appdirs-1.4.4 certifi-2020.12.5 distlib-0.3.1 filelock-3.0.12 pipenv-2020.11.15 six-1.15.0 virtualenv-20.2.2 virtualenv-clone-0.5.4
Removing intermediate container ff2a3a559ec9
 ---> bf0b844ef582
Step 6/21 : ADD Pipfile Pipfile.lock ./
 ---> 02da80cc3577
Step 7/21 : RUN apk add --no-cache mariadb-connector-c-dev libpq &&    apk add --no-cache --virtual _build-deps      build-base mariadb-dev postgresql-dev libjpeg-turbo-dev zlib-dev py-gevent libffi-dev &&    pipenv install --deploy --system &&    apk del _build-deps
 ---> Running in 0c4026e2083a
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/x86_64/APKINDEX.tar.gz
(1/9) Installing db (5.3.28-r1)
(2/9) Installing libsasl (2.1.27-r6)
(3/9) Installing libldap (2.4.50-r1)
(4/9) Installing libpq (12.5-r0)
(5/9) Installing pkgconf (1.7.2-r0)
(6/9) Installing openssl-dev (1.1.1i-r0)
(7/9) Installing zlib-dev (1.2.11-r3)
(8/9) Installing mariadb-connector-c (3.1.8-r1)
(9/9) Installing mariadb-connector-c-dev (3.1.8-r1)
Executing busybox-1.31.1-r19.trigger
OK: 23 MiB in 52 packages
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/x86_64/APKINDEX.tar.gz
(1/41) Installing libgcc (9.3.0-r2)
(2/41) Installing libstdc++ (9.3.0-r2)
(3/41) Installing binutils (2.34-r1)
(4/41) Installing libmagic (5.38-r0)
(5/41) Installing file (5.38-r0)
(6/41) Installing gmp (6.2.0-r0)
(7/41) Installing isl (0.18-r0)
(8/41) Installing libgomp (9.3.0-r2)
(9/41) Installing libatomic (9.3.0-r2)
(10/41) Installing libgphobos (9.3.0-r2)
(11/41) Installing mpfr4 (4.0.2-r4)
(12/41) Installing mpc1 (1.1.0-r1)
(13/41) Installing gcc (9.3.0-r2)
(14/41) Installing musl-dev (1.1.24-r10)
(15/41) Installing libc-dev (0.7.2-r3)
(16/41) Installing g++ (9.3.0-r2)
(17/41) Installing make (4.3-r0)
(18/41) Installing fortify-headers (1.1-r0)
(19/41) Installing patch (2.7.6-r6)
(20/41) Installing build-base (0.5-r2)
(21/41) Installing mariadb-common (10.4.15-r0)
(22/41) Installing libaio (0.3.112-r1)
(23/41) Installing pcre (8.44-r0)
(24/41) Installing mariadb-embedded (10.4.15-r0)
(25/41) Installing mariadb-dev (10.4.15-r0)
(26/41) Installing libxml2 (2.9.10-r5)
(27/41) Installing llvm10-libs (10.0.0-r2)
(28/41) Installing clang-libs (10.0.0-r2)
(29/41) Installing clang (10.0.0-r2)
(30/41) Installing llvm10 (10.0.0-r2)
(31/41) Installing icu-libs (67.1-r0)
(32/41) Installing icu (67.1-r0)
(33/41) Installing icu-dev (67.1-r0)
(34/41) Installing postgresql-libs (12.5-r0)
(35/41) Installing postgresql-dev (12.5-r0)
(36/41) Installing libjpeg-turbo-dev (2.0.5-r0)
(37/41) Installing py3-greenlet (0.4.15-r3)
(38/41) Installing py3-gevent (1.5.0-r0)
(39/41) Installing linux-headers (5.4.5-r1)
(40/41) Installing libffi-dev (3.3-r2)
(41/41) Installing _build-deps (20201223.192315)
Executing busybox-1.31.1-r19.trigger
OK: 468 MiB in 93 packages
Installing dependencies from Pipfile.lock (8a3371)...
An error occurred while installing greenlet==0.4.15; platform_python_implementation == 'CPython' --hash=sha256:99a26afdb82ea83a265137a398f570402aa1f2b5dfb4ac3300c026931817b163 --hash=sha256:9416443e219356e3c31f1f918a91badf2e37acf297e2fa13d24d1cc2380f8fbc --hash=sha256:000546ad01e6389e98626c1367be58efa613fa82a1be98b0c6fc24b563acc6d0 --hash=sha256:beeabe25c3b704f7d56b573f7d2ff88fc99f0138e43480cecdfcaa3b87fe4f87 --hash=sha256:37c9ba82bd82eb6a23c2e5acc03055c0e45697253b2393c9a50cef76a3985304 --hash=sha256:d634a7ea1fc3380ff96f9e44d8d22f38418c1c381d5fac680b272d7d90883720 --hash=sha256:51155342eb4d6058a0ffcd98a798fe6ba21195517da97e15fca3db12ab201e6e --hash=sha256:7457d685158522df483196b16ec648b28f8e847861adb01a55d41134e7734122 --hash=sha256:ac57fcdcfb0b73bb3203b58a14501abb7e5ff9ea5e2edfa06bb03035f0cff248 --hash=sha256:51503524dd6f152ab4ad1fbd168fc6c30b5795e8c70be4410a64940b3abb55c0 --hash=sha256:81fcd96a275209ef117e9ec91f75c731fa18dcfd9ffaa1c0adbdaa3616a86043 --hash=sha256:8041e2de00e745c0e05a502d6e6db310db7faa7c979b3a5877123548a4c0b214 --hash=sha256:0d48200bc50cbf498716712129eef819b1729339e34c3ae71656964dac907c28 --hash=sha256:a9f145660588187ff835c55a7d2ddf6abfc570c2651c276d3d4be8a2766db490 --hash=sha256:e538b8dae561080b542b0f5af64d47ef859f22517f7eca617bb314e0e03fd7ef --hash=sha256:853da4f9563d982e4121fed8c92eea1a4594a2299037b3034c3c898cb8e933d6 --hash=sha256:9854f612e1b59ec66804931df5add3b2d5ef0067748ea29dc60f0efdcda9a638 --hash=sha256:a19bf883b3384957e4a4a13e6bd1ae3d85ae87f4beb5957e35b0be287f12f4e4 --hash=sha256:8b4572c334593d449113f9dc8d19b93b7b271bdbe90ba7509eb178923327b625 --hash=sha256:bcb530089ff24f6458a81ac3fa699e8c00194208a724b644ecc68422e1111939 --hash=sha256:d97b0661e1aead761f0ded3b769044bb00ed5d33e1ec865e891a8b128bf7c656 --hash=sha256:23d12eacffa9d0f290c0fe0c4e81ba6d5f3a5b7ac3c30a5eaf0126bf4deda5c8! Will try again.
Ignoring importlib-metadata: markers 'python_version < "3.8"' don't match your environment
An error occurred while installing protobuf==3.12.1 --hash=sha256:eeb7502f59e889a88bcb59f299493e215d1864f3d75335ea04a413004eb4fe24 --hash=sha256:04d0b2bd99050d09393875a5a25fd12337b17f3ac2e29c0c1b8e65b277cbfe72 --hash=sha256:613ac49f6db266fba243daf60fb32af107cfe3678e5c003bb40a381b6786389d --hash=sha256:175d85370947f89e33b3da93f4ccdda3f326bebe3e599df5915ceb7f804cd9df --hash=sha256:60f32af25620abc4d7928d8197f9f25d49d558c5959aa1e08c686f974ac0b71a --hash=sha256:fdb1742f883ee4662e39fcc5916f2725fec36a5191a52123fec60f8c53b70495 --hash=sha256:05288e44638e91498f13127a3699a6528dec6f9d3084d60959d721bfb9ea5b98 --hash=sha256:4c7cae1f56056a4a2a2e3b00b26ab8550eae738bd9548f4ea0c2fcb88ed76ae5 --hash=sha256:519abfacbb421c3591d26e8daf7a4957763428db7267f7207e3693e29f6978db --hash=sha256:c45f5980ce32879391144b5766120fd7b8803129f127ce36bd060dd38824801f --hash=sha256:c0767f4d93ce4288475afe0571663c78870924f1f8881efd5406c10f070c75e4 --hash=sha256:fe554066c4962c2db0a1d4752655223eb948d2bfa0fb1c4a7f2c00ec07324f1c --hash=sha256:954bb14816edd24e746ba1a6b2d48c43576393bbde2fb8e1e3bd6d4504c7feac --hash=sha256:49fb6fab19cd3f30fa0e976eeedcbf2558e9061e5fa65b4fe51ded1f4002e04d --hash=sha256:9b1462c033a2cee7f4e8eb396905c69de2c532c3b835ff8f71f8e5fb77c38023 --hash=sha256:440a8c77531b3652f24999b249256ed01fd44c498ab0973843066681bd276685! Will try again.
Installing initially failed dependencies...
[InstallError]:   File "/usr/local/lib/python3.9/site-packages/pipenv/cli/command.py", line 233, in install
[InstallError]:       retcode = do_install(
[InstallError]:   File "/usr/local/lib/python3.9/site-packages/pipenv/core.py", line 2052, in do_install
[InstallError]:       do_init(
[InstallError]:   File "/usr/local/lib/python3.9/site-packages/pipenv/core.py", line 1304, in do_init
[InstallError]:       do_install_dependencies(
[InstallError]:   File "/usr/local/lib/python3.9/site-packages/pipenv/core.py", line 899, in do_install_dependencies
[InstallError]:       batch_install(
[InstallError]:   File "/usr/local/lib/python3.9/site-packages/pipenv/core.py", line 796, in batch_install
[InstallError]:       _cleanup_procs(procs, failed_deps_queue, retry=retry)
[InstallError]:   File "/usr/local/lib/python3.9/site-packages/pipenv/core.py", line 703, in _cleanup_procs
[InstallError]:       raise exceptions.InstallError(c.dep.name, extra=err_lines)
[pipenv.exceptions.InstallError]: Collecting greenlet==0.4.15
[pipenv.exceptions.InstallError]:   Downloading greenlet-0.4.15.tar.gz (59 kB)
[pipenv.exceptions.InstallError]: Building wheels for collected packages: greenlet
[pipenv.exceptions.InstallError]:   Building wheel for greenlet (setup.py): started
[pipenv.exceptions.InstallError]:   Building wheel for greenlet (setup.py): finished with status 'error'
[pipenv.exceptions.InstallError]:   ERROR: Command errored out with exit status 1:
[pipenv.exceptions.InstallError]:    command: /usr/local/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-d79nqyrb/greenlet_2e588de55df54fc7bb9ac7e40e15c806/setup.py'"'"'; __file__='"'"'/tmp/pip-install-d79nqyrb/greenlet_2e588de55df54fc7bb9ac7e40e15c806/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-dzzag50u
[pipenv.exceptions.InstallError]:        cwd: /tmp/pip-install-d79nqyrb/greenlet_2e588de55df54fc7bb9ac7e40e15c806/
[pipenv.exceptions.InstallError]:   Complete output (24 lines):
[pipenv.exceptions.InstallError]:   running bdist_wheel
[pipenv.exceptions.InstallError]:   running build
[pipenv.exceptions.InstallError]:   running build_ext
[pipenv.exceptions.InstallError]:   building 'greenlet' extension
[pipenv.exceptions.InstallError]:   creating build
[pipenv.exceptions.InstallError]:   creating build/temp.linux-x86_64-3.9
[pipenv.exceptions.InstallError]:   gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -DTHREAD_STACK_SIZE=0x100000 -fPIC -I/usr/local/include/python3.9 -c greenlet.c -o build/temp.linux-x86_64-3.9/greenlet.o
[pipenv.exceptions.InstallError]:   greenlet.c: In function 'g_initialstub':
[pipenv.exceptions.InstallError]:   greenlet.c:823:4: warning: 'PyEval_CallObjectWithKeywords' is deprecated [-Wdeprecated-declarations]
[pipenv.exceptions.InstallError]:     823 |    result = PyEval_CallObjectWithKeywords(
[pipenv.exceptions.InstallError]:         |    ^~~~~~
[pipenv.exceptions.InstallError]:   In file included from /usr/local/include/python3.9/Python.h:145,
[pipenv.exceptions.InstallError]:                    from greenlet.h:8,
[pipenv.exceptions.InstallError]:                    from greenlet.c:5:
[pipenv.exceptions.InstallError]:   /usr/local/include/python3.9/ceval.h:17:43: note: declared here
[pipenv.exceptions.InstallError]:      17 | Py_DEPRECATED(3.9) PyAPI_FUNC(PyObject *) PyEval_CallObjectWithKeywords(
[pipenv.exceptions.InstallError]:         |                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[pipenv.exceptions.InstallError]:   greenlet.c: In function 'green_dealloc':
[pipenv.exceptions.InstallError]:   greenlet.c:1046:4: error: '_Py_DEC_REFTOTAL' undeclared (first use in this function); did you mean '_Py_DECREF'?
[pipenv.exceptions.InstallError]:    1046 |    _Py_DEC_REFTOTAL;
[pipenv.exceptions.InstallError]:         |    ^~~~~~~~~~~~~~~~
[pipenv.exceptions.InstallError]:         |    _Py_DECREF
[pipenv.exceptions.InstallError]:   greenlet.c:1046:4: note: each undeclared identifier is reported only once for each function it appears in
[pipenv.exceptions.InstallError]:   error: command '/usr/bin/gcc' failed with exit code 1
[pipenv.exceptions.InstallError]:   ----------------------------------------
[pipenv.exceptions.InstallError]:   ERROR: Failed building wheel for greenlet
[pipenv.exceptions.InstallError]:   Running setup.py clean for greenlet
[pipenv.exceptions.InstallError]: Failed to build greenlet
[pipenv.exceptions.InstallError]: Installing collected packages: greenlet
[pipenv.exceptions.InstallError]:     Running setup.py install for greenlet: started
[pipenv.exceptions.InstallError]:     Running setup.py install for greenlet: finished with status 'error'
[pipenv.exceptions.InstallError]:     ERROR: Command errored out with exit status 1:
[pipenv.exceptions.InstallError]:      command: /usr/local/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-d79nqyrb/greenlet_2e588de55df54fc7bb9ac7e40e15c806/setup.py'"'"'; __file__='"'"'/tmp/pip-install-d79nqyrb/greenlet_2e588de55df54fc7bb9ac7e40e15c806/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-ce6h1g8e/install-record.txt --single-version-externally-managed --compile --install-headers /usr/local/include/python3.9/greenlet
[pipenv.exceptions.InstallError]:          cwd: /tmp/pip-install-d79nqyrb/greenlet_2e588de55df54fc7bb9ac7e40e15c806/
[pipenv.exceptions.InstallError]:     Complete output (24 lines):
[pipenv.exceptions.InstallError]:     running install
[pipenv.exceptions.InstallError]:     running build
[pipenv.exceptions.InstallError]:     running build_ext
[pipenv.exceptions.InstallError]:     building 'greenlet' extension
[pipenv.exceptions.InstallError]:     creating build
[pipenv.exceptions.InstallError]:     creating build/temp.linux-x86_64-3.9
[pipenv.exceptions.InstallError]:     gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -DTHREAD_STACK_SIZE=0x100000 -fPIC -I/usr/local/include/python3.9 -c greenlet.c -o build/temp.linux-x86_64-3.9/greenlet.o
[pipenv.exceptions.InstallError]:     greenlet.c: In function 'g_initialstub':
[pipenv.exceptions.InstallError]:     greenlet.c:823:4: warning: 'PyEval_CallObjectWithKeywords' is deprecated [-Wdeprecated-declarations]
[pipenv.exceptions.InstallError]:       823 |    result = PyEval_CallObjectWithKeywords(
[pipenv.exceptions.InstallError]:           |    ^~~~~~
[pipenv.exceptions.InstallError]:     In file included from /usr/local/include/python3.9/Python.h:145,
[pipenv.exceptions.InstallError]:                      from greenlet.h:8,
[pipenv.exceptions.InstallError]:                      from greenlet.c:5:
[pipenv.exceptions.InstallError]:     /usr/local/include/python3.9/ceval.h:17:43: note: declared here
[pipenv.exceptions.InstallError]:        17 | Py_DEPRECATED(3.9) PyAPI_FUNC(PyObject *) PyEval_CallObjectWithKeywords(
[pipenv.exceptions.InstallError]:           |                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[pipenv.exceptions.InstallError]:     greenlet.c: In function 'green_dealloc':
[pipenv.exceptions.InstallError]:     greenlet.c:1046:4: error: '_Py_DEC_REFTOTAL' undeclared (first use in this function); did you mean '_Py_DECREF'?
[pipenv.exceptions.InstallError]:      1046 |    _Py_DEC_REFTOTAL;
[pipenv.exceptions.InstallError]:           |    ^~~~~~~~~~~~~~~~
[pipenv.exceptions.InstallError]:           |    _Py_DECREF
[pipenv.exceptions.InstallError]:     greenlet.c:1046:4: note: each undeclared identifier is reported only once for each function it appears in
[pipenv.exceptions.InstallError]:     error: command '/usr/bin/gcc' failed with exit code 1
[pipenv.exceptions.InstallError]:     ----------------------------------------
[pipenv.exceptions.InstallError]: ERROR: Command errored out with exit status 1: /usr/local/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-d79nqyrb/greenlet_2e588de55df54fc7bb9ac7e40e15c806/setup.py'"'"'; __file__='"'"'/tmp/pip-install-d79nqyrb/greenlet_2e588de55df54fc7bb9ac7e40e15c806/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-ce6h1g8e/install-record.txt --single-version-externally-managed --compile --install-headers /usr/local/include/python3.9/greenlet Check the logs for full command output.
ERROR: Couldn't install package: greenlet
 Package installation failed...
/usr/local/lib/python3.9/subprocess.py:1048: ResourceWarning: subprocess 19720 is still running
  _warn("subprocess %s is still running" % self.pid,
sys:1: ResourceWarning: unclosed file <_io.FileIO name=6 mode='wb' closefd=True>
sys:1: ResourceWarning: unclosed file <_io.FileIO name=7 mode='rb' closefd=True>
ERROR: Service 'kegbot' failed to build : The command '/bin/sh -c apk add --no-cache mariadb-connector-c-dev libpq &&    apk add --no-cache --virtual _build-deps      build-base mariadb-dev postgresql-dev libjpeg-turbo-dev zlib-dev py-gevent libffi-dev &&    pipenv install --deploy --system &&    apk del _build-deps' returned a non-zero code: 1
```