### PR TITLE
Fix issue #419

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,11 @@ RUN apk update && \
      libjpeg-turbo-dev \
      zlib-dev \
      py-gevent \
-     libffi-dev
+     libffi-dev \
+     musl-dev \
+     python3-dev \
+     openssl-dev \
+     cargo
 
 RUN pip install poetry
 


### PR DESCRIPTION
As noted in #419, Docker build will not run because Rust is now required to [build the cryptography wheel](https://github.com/pyca/cryptography/issues/5771). This pull request adds additional build dependencies.